### PR TITLE
feat: add awards and competitions section

### DIFF
--- a/src/components/Awards.astro
+++ b/src/components/Awards.astro
@@ -1,0 +1,41 @@
+---
+import { siteConfig } from "../config";
+const hasAwards = siteConfig.awardsAndCompetitions && siteConfig.awardsAndCompetitions.length > 0;
+---
+{hasAwards && (
+  <section id="awards" class="p-8 sm:p-12 md:p-16 lg:p-24">
+    <div>
+      <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-16 items-start">
+        <div class="lg:col-span-4">
+          <h2 class="text-3xl sm:text-4xl md:text-5xl xl:text-7xl font-bold text-gray-900">
+            Awards & Competitions
+          </h2>
+          <div
+            class="w-[75px] h-[5px] mt-2 rounded-full"
+            style={`background-color: ${siteConfig.accentColor}`}
+          />
+        </div>
+        <div class="lg:col-span-8">
+          <div class="space-y-8">
+            {siteConfig.awardsAndCompetitions.map((award) => (
+              <div class="bg-white rounded-lg shadow-sm border border-gray-100 p-4 sm:p-5 md:p-6 hover:shadow-md transition-shadow duration-300">
+                <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between mb-4">
+                  <div>
+                    <h3 class="text-lg sm:text-xl font-semibold text-gray-900">
+                      {award.title}
+                    </h3>
+                    <p class="text-base sm:text-lg" style={`color: ${siteConfig.accentColor}`}>
+                      {award.awardedBy}
+                    </p>
+                  </div>
+                  <span class="text-xs sm:text-sm text-gray-500 mt-2 sm:mt-0">{award.year}</span>
+                </div>
+                <p class="text-sm sm:text-base text-gray-600">{award.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+)}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import About from "../components/About.astro";
 import Projects from "../components/Projects.astro";
 import Experience from "../components/Experience.astro";
 import Education from "../components/Education.astro";
+import Awards from "../components/Awards.astro";
 import Footer from "../components/Footer.astro";
 import { siteConfig } from "../config";
 import "../styles/global.css";
@@ -33,6 +34,7 @@ import "../styles/global.css";
       <Projects />
       <Experience />
       <Education />
+      <Awards />
     </section>
     <Footer />
   </body>


### PR DESCRIPTION
## Summary
- add Awards & Competitions component powered by `siteConfig.awardsAndCompetitions`
- render Awards on the home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68968449b3b08333af735534043d069e