### PR TITLE
Add contact section with mailto link

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -1,0 +1,32 @@
+---
+import { siteConfig } from "../config";
+---
+
+<section id="contact" class="p-8 sm:p-12 md:p-16 lg:p-24">
+  <div>
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-16 items-start">
+      <div class="lg:col-span-4">
+        <h2 class="text-3xl sm:text-4xl md:text-5xl xl:text-7xl font-bold text-gray-900">
+          Contact
+        </h2>
+        <div
+          class="w-[75px] h-[5px] mt-2 rounded-full"
+          style={`background-color: ${siteConfig.accentColor}`}
+        />
+      </div>
+
+      <div class="lg:col-span-8 space-y-8">
+        <p class="text-lg sm:text-xl md:text-2xl leading-relaxed text-gray-600">
+          Feel free to reach out for collaborations or just a friendly hello.
+        </p>
+        <a
+          href={`mailto:${siteConfig.social.email}`}
+          class="inline-block px-6 py-3 text-lg font-medium text-white rounded-lg"
+          style={`background-color: ${siteConfig.accentColor}`}
+        >
+          Contactez-moi
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import Projects from "../components/Projects.astro";
 import Experience from "../components/Experience.astro";
 import Education from "../components/Education.astro";
 import Awards from "../components/Awards.astro";
+import Contact from "../components/Contact.astro";
 import Footer from "../components/Footer.astro";
 import { siteConfig } from "../config";
 import "../styles/global.css";
@@ -35,6 +36,7 @@ import "../styles/global.css";
       <Experience />
       <Education />
       <Awards />
+      <Contact />
     </section>
     <Footer />
   </body>


### PR DESCRIPTION
## Summary
- add new Contact component featuring a mailto link
- include Contact section on the home page under existing sections

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68968d2d01988333a8fa119a6fa96504