### PR TITLE
feat: add education logos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.1.0
+
+- Added optional institution logos to the education section
+- Updated Polytechnique Montréal logo to use Google Drive hosted image
+
 ### 2.0.0
 
 - Complete rewrite of the template using Astro and Tailwind

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,4 +61,4 @@ The `src/config.ts` exports a `siteConfig` object with these sections:
 - skills: string[]
 - projects: array of {name, description, link, skills}
 - experience: array of {company, title, dateRange, bullets}
-- education: array of {school, degree, dateRange, achievements}
+- education: array of {school, degree, dateRange, achievements, logo?}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The template is designed to be easily customizable through the `src/config.ts` f
 - **Skills**: List of technical skills
 - **Projects**: Project showcase with descriptions and links
 - **Experience**: Work history with bullet points
-- **Education**: Educational background and achievements
+- **Education**: Educational background, achievements, and logos
 
 If skills, projects, experience, or education are removed from the config, those sections will be hidden entirely.
 
@@ -107,6 +107,7 @@ education: [
     school: "University Name",
     degree: "Bachelor of Science in Computer Science",
     dateRange: "2014 - 2018",
+    logo: "/logos/university.png",
     achievements: [
       "Graduated Magna Cum Laude with 3.8 GPA",
       "Dean's List all semesters",
@@ -125,7 +126,8 @@ The template uses [Tabler Icons](https://tabler.io/icons) for all icons. If you 
 ```
 devportfolio/
 ├── public/
-│   └── favicon.svg          # Site favicon
+│   ├── favicon.svg          # Site favicon
+│   └── logos/               # Education logos
 ├── src/
 │   ├── components/          # Astro components
 │   │   ├── About.astro      # About section

--- a/src/components/Education.astro
+++ b/src/components/Education.astro
@@ -23,16 +23,25 @@ const hasEducation = siteConfig.education && siteConfig.education.length > 0;
               {siteConfig.education.map((edu) => (
                 <div class="bg-white rounded-lg shadow-sm border border-gray-100 p-4 sm:p-5 md:p-6 hover:shadow-md transition-shadow duration-300">
                   <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between mb-4">
-                    <div>
-                      <h3 class="text-lg sm:text-xl font-semibold text-gray-900">
-                        {edu.degree}
-                      </h3>
-                      <p
-                        class="text-base sm:text-lg"
-                        style={`color: ${siteConfig.accentColor}`}
-                      >
-                        {edu.school}
-                      </p>
+                    <div class="flex items-center gap-4">
+                      {edu.logo && (
+                        <img
+                          src={edu.logo}
+                          alt={`${edu.school} logo`}
+                          class="w-12 h-12 object-contain flex-shrink-0"
+                        />
+                      )}
+                      <div>
+                        <h3 class="text-lg sm:text-xl font-semibold text-gray-900">
+                          {edu.degree}
+                        </h3>
+                        <p
+                          class="text-base sm:text-lg"
+                          style={`color: ${siteConfig.accentColor}`}
+                        >
+                          {edu.school}
+                        </p>
+                      </div>
                     </div>
                     <span class="text-xs sm:text-sm text-gray-500 mt-2 sm:mt-0">
                       {edu.dateRange}

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,6 +108,7 @@ export const siteConfig = {
       school: "Polytechnique Montréal",
       degree: "Bachelor of Engineering – Mechanical Engineering (Graduate)",
       dateRange: "2021 – 2025",
+      logo: "https://drive.google.com/uc?export=view&id=1LZvZvBNhFNipsTIO22A5rge21Uzlm6Wq",
       achievements: [
         "Recipient – Perseverance Scholarship (2023) – Family J.W. McConnell / Polytechnique Montréal",
         "Recipient – Stantec Diversity & Inclusion Scholarship (2024)",


### PR DESCRIPTION
## Summary
- allow education items to specify an institution logo
- render education logos in the Education component
- document logo support in config and changelog
- use Polytechnique Montréal logo hosted on Google Drive

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896b6282ad48333a319b33c88f23174