### PR TITLE
Enhance education card hover effects

### DIFF
--- a/src/components/Education.astro
+++ b/src/components/Education.astro
@@ -21,7 +21,10 @@ const hasEducation = siteConfig.education && siteConfig.education.length > 0;
           <div class="lg:col-span-8">
             <div class="space-y-8">
               {siteConfig.education.map((edu) => (
-                <div class="bg-white rounded-lg shadow-sm border border-gray-100 p-4 sm:p-5 md:p-6 hover:shadow-md transition-shadow duration-300">
+                <div
+                  class="bg-white rounded-lg shadow-sm border border-gray-100 p-4 sm:p-5 md:p-6 hover:shadow-md group transform transition-all duration-300 hover:-translate-y-1 hover:scale-105 hover:border-[var(--accent-color)] edu-card-hover"
+                  style={`--accent-color: ${siteConfig.accentColor}`}
+                >
                   <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between mb-4">
                     <div class="flex items-center gap-4">
                       {edu.logo && (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,3 +3,16 @@
 body {
   font-family: 'IBM Plex Mono', monospace;
 }
+
+.edu-card-hover {
+  @apply relative;
+}
+
+.edu-card-hover::after {
+  content: "";
+  @apply absolute inset-0 border border-transparent transition-colors duration-300 pointer-events-none;
+}
+
+.edu-card-hover:hover::after {
+  border-color: var(--accent-color);
+}


### PR DESCRIPTION
## Summary
- add transform and scale hover animations to education cards using accent color border
- add `.edu-card-hover` CSS with pseudo-element border transition for finer control

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896d9838f34833380779a42c1e25163