### PR TITLE
Add glow hover to experience and awards sections

### DIFF
--- a/src/components/Awards.astro
+++ b/src/components/Awards.astro
@@ -3,7 +3,11 @@ import { siteConfig } from "../config";
 const hasAwards = siteConfig.awardsAndCompetitions && siteConfig.awardsAndCompetitions.length > 0;
 ---
 {hasAwards && (
-  <section id="awards" class="p-8 sm:p-12 md:p-16 lg:p-24">
+  <section
+    id="awards"
+    class="p-8 sm:p-12 md:p-16 lg:p-24"
+    style={`--accent-color: ${siteConfig.accentColor}; --accent-color-light: #3b82f6; --accent-color-dark: #1e40af;`}
+  >
     <div>
       <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-16 items-start">
         <div class="lg:col-span-4">
@@ -12,25 +16,28 @@ const hasAwards = siteConfig.awardsAndCompetitions && siteConfig.awardsAndCompet
           </h2>
           <div
             class="w-[75px] h-[5px] mt-2 rounded-full"
-            style={`background-color: ${siteConfig.accentColor}`}
+            style="background-color: var(--accent-color)"
           />
         </div>
         <div class="lg:col-span-8">
           <div class="space-y-8">
             {siteConfig.awardsAndCompetitions.map((award) => (
-              <div class="bg-white rounded-lg shadow-sm border border-gray-100 p-4 sm:p-5 md:p-6 hover:shadow-md transition-shadow duration-300">
-                <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between mb-4">
-                  <div>
-                    <h3 class="text-lg sm:text-xl font-semibold text-gray-900">
-                      {award.title}
-                    </h3>
-                    <p class="text-base sm:text-lg" style={`color: ${siteConfig.accentColor}`}>
-                      {award.awardedBy}
-                    </p>
+              <div class="glow-container">
+                <article class="glow-card bg-white rounded-lg shadow-sm border border-gray-100 p-4 sm:p-5 md:p-6 hover:shadow-md transition-all duration-300 relative cursor-pointer">
+                  <div class="glows"></div>
+                  <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between mb-4">
+                    <div>
+                      <h3 class="text-lg sm:text-xl font-semibold text-gray-900">
+                        {award.title}
+                      </h3>
+                      <p class="text-base sm:text-lg" style="color: var(--accent-color)">
+                        {award.awardedBy}
+                      </p>
+                    </div>
+                    <span class="text-xs sm:text-sm text-gray-500 mt-2 sm:mt-0">{award.year}</span>
                   </div>
-                  <span class="text-xs sm:text-sm text-gray-500 mt-2 sm:mt-0">{award.year}</span>
-                </div>
-                <p class="text-sm sm:text-base text-gray-600">{award.description}</p>
+                  <p class="text-sm sm:text-base text-gray-600">{award.description}</p>
+                </article>
               </div>
             ))}
           </div>

--- a/src/components/Education.astro
+++ b/src/components/Education.astro
@@ -5,7 +5,11 @@ const hasEducation = siteConfig.education && siteConfig.education.length > 0;
 
 {
   hasEducation && (
-    <section id="education" class="p-8 sm:p-12 md:p-16 lg:p-24">
+    <section
+      id="education"
+      class="p-8 sm:p-12 md:p-16 lg:p-24"
+      style={`--accent-color: ${siteConfig.accentColor}; --accent-color-light: #3b82f6; --accent-color-dark: #1e40af;`}
+    >
       <div>
         <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-16 items-start">
           <div class="lg:col-span-4">
@@ -20,50 +24,117 @@ const hasEducation = siteConfig.education && siteConfig.education.length > 0;
 
           <div class="lg:col-span-8">
             <div class="space-y-8">
-              {siteConfig.education.map((edu) => (
-                <div class="bg-white rounded-lg shadow-sm border border-gray-100 p-4 sm:p-5 md:p-6 hover:shadow-md transition-shadow duration-300">
-                  <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between mb-4">
-                    <div class="flex items-center gap-4">
-                      {edu.logo && (
-                        <img
-                          src={edu.logo}
-                          alt={`${edu.school} logo`}
-                          class="w-12 h-12 object-contain flex-shrink-0"
-                        />
-                      )}
-                      <div>
-                        <h3 class="text-lg sm:text-xl font-semibold text-gray-900">
-                          {edu.degree}
-                        </h3>
-                        <p
-                          class="text-base sm:text-lg"
-                          style={`color: ${siteConfig.accentColor}`}
-                        >
-                          {edu.school}
-                        </p>
+{siteConfig.education.map((edu) => (
+                <div class="glow-container">
+                  <article
+                    class="glow-card edu-card-hover group transform transition-all duration-300 hover:-translate-y-1 hover:scale-105 hover:border-[var(--accent-color)] bg-white rounded-lg shadow-sm border border-gray-100 p-4 sm:p-5 md:p-6 hover:shadow-md relative cursor-pointer"
+                  >
+                    <div class="glows"></div>
+                    <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between mb-4">
+                      <div class="flex items-center gap-4">
+                        {edu.logo && (
+                          <img
+                            src={edu.logo}
+                            alt={`${edu.school} logo`}
+                            class="w-12 h-12 object-contain flex-shrink-0"
+                          />
+                        )}
+                        <div>
+                          <h3 class="text-lg sm:text-xl font-semibold text-gray-900">
+                            {edu.degree}
+                          </h3>
+                          <p
+                            class="text-base sm:text-lg"
+                            style={`color: ${siteConfig.accentColor}`}
+                          >
+                            {edu.school}
+                          </p>
+                        </div>
                       </div>
+                      <span class="text-xs sm:text-sm text-gray-500 mt-2 sm:mt-0">
+                        {edu.dateRange}
+                      </span>
                     </div>
-                    <span class="text-xs sm:text-sm text-gray-500 mt-2 sm:mt-0">
-                      {edu.dateRange}
-                    </span>
-                  </div>
 
-                  <ul class="space-y-2">
-                    {edu.achievements.map((achievement) => (
-                      <li class="flex items-start">
-                        <span class="inline-block w-1.5 h-1.5 rounded-full bg-gray-400 mt-2 mr-3 flex-shrink-0" />
-                        <span class="text-sm sm:text-base text-gray-600">
-                          {achievement}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
+                    <ul class="space-y-2">
+                      {edu.achievements.map((achievement) => (
+                        <li class="flex items-start">
+                          <span class="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-color)] mt-2 mr-3 flex-shrink-0" />
+                          <span class="text-sm sm:text-base text-gray-600">
+                            {achievement}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </article>
                 </div>
               ))}
             </div>
           </div>
         </div>
       </div>
+      <script>
+        document.addEventListener('DOMContentLoaded', () => {
+          const CONFIG = {
+            proximity: 40,
+            spread: 80,
+            blur: 12,
+            gap: 32,
+            vertical: false,
+            opacity: 0,
+          };
+
+          const CONTAINERS = document.querySelectorAll('.glow-container');
+          const CARDS = document.querySelectorAll('.glow-card');
+
+          const UPDATE = (event) => {
+            for (const CARD of CARDS) {
+              const BOUNDS = CARD.getBoundingClientRect();
+
+              if (
+                event?.x > BOUNDS.left - CONFIG.proximity &&
+                event?.x < BOUNDS.left + BOUNDS.width + CONFIG.proximity &&
+                event?.y > BOUNDS.top - CONFIG.proximity &&
+                event?.y < BOUNDS.top + BOUNDS.height + CONFIG.proximity
+              ) {
+                CARD.style.setProperty('--active', 1);
+              } else {
+                CARD.style.setProperty('--active', CONFIG.opacity);
+              }
+
+              const CENTER = [
+                BOUNDS.left + BOUNDS.width * 0.5,
+                BOUNDS.top + BOUNDS.height * 0.5,
+              ];
+
+              let ANGLE =
+                (Math.atan2(event?.y - CENTER[1], event?.x - CENTER[0]) * 180) /
+                Math.PI;
+
+              ANGLE = ANGLE < 0 ? ANGLE + 360 : ANGLE;
+
+              CARD.style.setProperty('--start', ANGLE + 90);
+            }
+          };
+
+          document.body.addEventListener('pointermove', UPDATE);
+
+          const RESTYLE = () => {
+            for (const CONTAINER of CONTAINERS) {
+              CONTAINER.style.setProperty('--gap', CONFIG.gap);
+              CONTAINER.style.setProperty('--blur', CONFIG.blur);
+              CONTAINER.style.setProperty('--spread', CONFIG.spread);
+              CONTAINER.style.setProperty(
+                '--direction',
+                CONFIG.vertical ? 'column' : 'row'
+              );
+            }
+          };
+
+          RESTYLE();
+          UPDATE();
+        });
+      </script>
     </section>
   )
 }

--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -5,7 +5,11 @@ const hasExperience = siteConfig.experience && siteConfig.experience.length > 0;
 
 {
   hasExperience && (
-    <section id="experience" class="p-8 sm:p-12 md:p-16 lg:p-24">
+    <section
+      id="experience"
+      class="p-8 sm:p-12 md:p-16 lg:p-24"
+      style={`--accent-color: ${siteConfig.accentColor}; --accent-color-light: #3b82f6; --accent-color-dark: #1e40af;`}
+    >
       <div>
         <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-16 items-start">
           <div class="lg:col-span-4">
@@ -14,7 +18,7 @@ const hasExperience = siteConfig.experience && siteConfig.experience.length > 0;
             </h2>
             <div
               class="w-[75px] h-[5px] mt-2 rounded-full"
-              style={`background-color: ${siteConfig.accentColor}`}
+              style="background-color: var(--accent-color)"
             />
           </div>
 
@@ -25,7 +29,7 @@ const hasExperience = siteConfig.experience && siteConfig.experience.length > 0;
                   {/* Timeline dot at top of card */}
                   <div
                     class="absolute left-1/2 -top-2 w-4 h-4 bg-white border-2 rounded-full -translate-x-1/2 z-20 transition-all duration-300"
-                    style={`border-color: ${siteConfig.accentColor}; background-color: ${siteConfig.accentColor}`}
+                    style="border-color: var(--accent-color); background-color: var(--accent-color)"
                   />
 
                   {/* Connecting line below card */}
@@ -34,34 +38,37 @@ const hasExperience = siteConfig.experience && siteConfig.experience.length > 0;
                   )}
 
                   {/* Experience card */}
-                  <div class="bg-white rounded-lg shadow-sm border border-gray-100 p-4 sm:p-5 md:p-6 hover:shadow-md transition-shadow duration-300">
-                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4">
-                      <div>
-                        <h3 class="text-lg sm:text-xl font-semibold text-gray-900">
-                          {exp.title}
-                        </h3>
-                        <p
-                          class="text-base sm:text-lg"
-                          style={`color: ${siteConfig.accentColor}`}
-                        >
-                          {exp.company}
-                        </p>
+                  <div class="glow-container">
+                    <article class="glow-card bg-white rounded-lg shadow-sm border border-gray-100 p-4 sm:p-5 md:p-6 hover:shadow-md transition-all duration-300 relative cursor-pointer">
+                      <div class="glows"></div>
+                      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4">
+                        <div>
+                          <h3 class="text-lg sm:text-xl font-semibold text-gray-900">
+                            {exp.title}
+                          </h3>
+                          <p
+                            class="text-base sm:text-lg"
+                            style="color: var(--accent-color)"
+                          >
+                            {exp.company}
+                          </p>
+                        </div>
+                        <span class="text-xs sm:text-sm text-gray-500 mt-2 sm:mt-0">
+                          {exp.dateRange}
+                        </span>
                       </div>
-                      <span class="text-xs sm:text-sm text-gray-500 mt-2 sm:mt-0">
-                        {exp.dateRange}
-                      </span>
-                    </div>
 
-                    <ul class="space-y-2">
-                      {exp.bullets.map((bullet) => (
-                        <li class="flex items-start">
-                          <span class="inline-block w-1.5 h-1.5 rounded-full bg-gray-400 mt-2 mr-3 flex-shrink-0" />
-                          <span class="text-sm sm:text-base text-gray-600">
-                            {bullet}
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
+                      <ul class="space-y-2">
+                        {exp.bullets.map((bullet) => (
+                          <li class="flex items-start">
+                            <span class="inline-block w-1.5 h-1.5 rounded-full bg-[var(--accent-color)] mt-2 mr-3 flex-shrink-0" />
+                            <span class="text-sm sm:text-base text-gray-600">
+                              {bullet}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </article>
                   </div>
                 </div>
               ))}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,3 +3,112 @@
 body {
   font-family: 'IBM Plex Mono', monospace;
 }
+
+/* Glow card effect */
+.glow-container {
+  --spread: 60;
+}
+
+.glow-card {
+  --active: 0.15;
+  --start: 0;
+}
+
+.glow-card:is(:hover, :focus-visible) {
+  z-index: 2;
+}
+
+.glows {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  filter: blur(calc(var(--blur) * 1px));
+}
+
+
+.glows::after,
+.glows::before {
+  --alpha: 0;
+  content: "";
+  background: conic-gradient(from 180deg at 50% 70%,
+      var(--accent-color-light) 0deg,
+      var(--accent-color) 72deg,
+      var(--accent-color-light) 144deg,
+      var(--accent-color-dark) 216deg,
+      var(--accent-color) 288deg,
+      #ffffff 1turn);
+  background-attachment: fixed;
+  position: absolute;
+  inset: -5px;
+  border: 8px solid transparent;
+  border-radius: 12px;
+  mask: linear-gradient(#0000, #0000),
+    conic-gradient(from calc((var(--start) - (var(--spread) * 0.5)) * 1deg),
+      #000 0deg,
+      #fff,
+      #0000 calc(var(--spread) * 1deg));
+  mask-composite: intersect;
+  mask-clip: padding-box, border-box;
+  opacity: var(--active);
+  transition: opacity 1s;
+}
+
+.glow-card::before {
+  position: absolute;
+  inset: 0;
+  border: 2px solid transparent;
+  content: "";
+  border-radius: 12px;
+  pointer-events: none;
+  background: var(--accent-color-light);
+  background-attachment: fixed;
+  border-radius: 12px;
+  mask: linear-gradient(#0000, #0000),
+    conic-gradient(from calc(((var(--start) + (var(--spread) * 0.25)) - (var(--spread) * 1.5)) * 1deg),
+      #ffffff26 0deg,
+      white,
+      #ffffff26 calc(var(--spread) * 2.5deg));
+  mask-clip: padding-box, border-box;
+  mask-composite: intersect;
+  opacity: var(--active);
+  transition: opacity 1s;
+}
+
+.glow-card::after {
+  --bg-size: 100%;
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  background: conic-gradient(from 180deg at 50% 70%,
+      var(--accent-color-light) 0deg,
+      var(--accent-color) 72deg,
+      var(--accent-color-light) 144deg,
+      var(--accent-color-dark) 216deg,
+      var(--accent-color) 288deg,
+      #ffffff 1turn);
+  background-attachment: fixed;
+  border-radius: 12px;
+  opacity: var(--active, 0);
+  transition: opacity 1s;
+  --alpha: 0;
+  inset: 0;
+  border: 2px solid transparent;
+  mask: linear-gradient(#0000, #0000),
+    conic-gradient(from calc(((var(--start) + (var(--spread) * 0.25)) - (var(--spread) * 0.5)) * 1deg),
+      #0000 0deg,
+      #fff,
+      #0000 calc(var(--spread) * 0.5deg));
+  filter: brightness(1.5);
+  mask-clip: padding-box, border-box;
+  mask-composite: intersect;
+}
+
+/* Additional hover style for education cards */
+.edu-card-hover::after {
+  box-shadow: 0 0 0 0 var(--accent-color);
+  transition: opacity 1s, box-shadow 0.3s;
+}
+
+.edu-card-hover:hover::after {
+  box-shadow: 0 0 0 3px var(--accent-color);
+}


### PR DESCRIPTION
## Summary
- apply glow-card hover animation to experience timeline and awards list using accent color variables
- color timeline dots and bullet markers with accent palette for consistency
- initialize hover script on `DOMContentLoaded` so all sections participate
- restore education card hover classes and reusable `.edu-card-hover` style after failed merge

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896d9838f34833380779a42c1e25163