### PR TITLE
Resize awards heading to fit grid

### DIFF
--- a/src/components/Awards.astro
+++ b/src/components/Awards.astro
@@ -11,11 +11,11 @@ const hasAwards = siteConfig.awardsAndCompetitions && siteConfig.awardsAndCompet
     <div>
       <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-16 items-start">
         <div class="lg:col-span-4">
-          <h2 class="text-3xl sm:text-4xl md:text-5xl xl:text-7xl font-bold text-gray-900">
+          <h2 class="text-3xl sm:text-4xl md:text-5xl xl:text-6xl font-bold text-gray-900">
             Awards & Competitions
           </h2>
           <div
-            class="w-[75px] h-[5px] mt-2 rounded-full"
+            class="w-[75px] h-[5px] mt-2 mb-6 rounded-full"
             style="background-color: var(--accent-color)"
           />
         </div>


### PR DESCRIPTION
## Summary
- reduce Awards heading size on xl breakpoint
- add bottom margin beneath Awards label

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897b8130c908333a6cd896edaf1c2ff